### PR TITLE
Add loan retrieval and extension endpoints

### DIFF
--- a/BookLibwithSub.API/Controllers/LoansController.cs
+++ b/BookLibwithSub.API/Controllers/LoansController.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.IdentityModel.Tokens.Jwt;
 using BookLibwithSub.Service.Constants;
@@ -70,6 +72,42 @@ namespace BookLibwithSub.API.Controllers
             var userId = int.Parse(User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "0");
             var loans = await _loanService.GetActiveLoansAsync(userId);
             return Ok(loans);
+        }
+
+        public record LoanItemResponse(int LoanItemID, int BookID, DateTime DueDate, DateTime? ReturnedDate, string Status);
+        public record LoanResponse(int LoanID, int SubscriptionID, DateTime LoanDate, DateTime? ReturnDate, string Status, IEnumerable<LoanItemResponse> Items);
+
+        [HttpGet("{loanId}")]
+        [Authorize(Roles = Roles.User)]
+        public async Task<IActionResult> GetLoan(int loanId)
+        {
+            var userId = int.Parse(User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "0");
+            var loan = await _loanService.GetLoanAsync(loanId, userId);
+            if (loan == null) return NotFound();
+            var response = new LoanResponse(
+                loan.LoanID,
+                loan.SubscriptionID,
+                loan.LoanDate,
+                loan.ReturnDate,
+                loan.Status,
+                loan.LoanItems.Select(li => new LoanItemResponse(li.LoanItemID, li.BookID, li.DueDate, li.ReturnedDate, li.Status))
+            );
+            return Ok(response);
+        }
+
+        public class ExtendLoanRequest
+        {
+            public DateTime? NewDueDate { get; set; }
+            public int? DaysToExtend { get; set; }
+        }
+
+        [HttpPut("{loanId}/extend")]
+        [Authorize(Roles = Roles.User)]
+        public async Task<IActionResult> ExtendLoan(int loanId, [FromBody] ExtendLoanRequest request)
+        {
+            var userId = int.Parse(User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "0");
+            await _loanService.ExtendLoanAsync(loanId, userId, request.NewDueDate, request.DaysToExtend);
+            return Ok();
         }
     }
 }

--- a/BookLibwithSub.Repo/Interfaces/ILoanRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ILoanRepository.cs
@@ -12,6 +12,7 @@ namespace BookLibwithSub.Repo.Interfaces
         Task<Loan?> GetByIdAsync(int loanId);
         Task AddItemsAsync(Loan loan, IEnumerable<LoanItem> items);
         Task<LoanItem> ReturnAsync(int loanItemId);
+        Task ExtendLoanAsync(Loan loan, DateTime? newDueDate, int? daysToExtend);
         Task<List<Loan>> GetLoansByUserAsync(int userId);
         Task<List<Loan>> GetActiveLoansByUserAsync(int userId);
     }

--- a/BookLibwithSub.Repo/repository/LoanRepository.cs
+++ b/BookLibwithSub.Repo/repository/LoanRepository.cs
@@ -44,6 +44,7 @@ namespace BookLibwithSub.Repo.repository
             return await _context.Loans
                 .Include(l => l.Subscription)
                     .ThenInclude(s => s.SubscriptionPlan)
+                .Include(l => l.LoanItems)
                 .FirstOrDefaultAsync(l => l.LoanID == loanId);
         }
 
@@ -104,6 +105,19 @@ namespace BookLibwithSub.Repo.repository
                              l.LoanItems.Any(li => li.Status != "Returned"))
                 .Include(l => l.LoanItems.Where(li => li.Status != "Returned"))
                 .ToListAsync();
+        }
+
+        public async Task ExtendLoanAsync(Loan loan, DateTime? newDueDate, int? daysToExtend)
+        {
+            foreach (var item in loan.LoanItems.Where(li => li.Status != "Returned"))
+            {
+                if (newDueDate.HasValue)
+                    item.DueDate = newDueDate.Value;
+                else if (daysToExtend.HasValue)
+                    item.DueDate = item.DueDate.AddDays(daysToExtend.Value);
+            }
+
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/BookLibwithSub.Service/Interfaces/ILoanService.cs
+++ b/BookLibwithSub.Service/Interfaces/ILoanService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BookLibwithSub.Repo.Entities;
@@ -9,6 +10,8 @@ namespace BookLibwithSub.Service.Interfaces
         Task BorrowAsync(int subscriptionId, IEnumerable<int> bookIds);
         Task AddItemsAsync(int loanId, IEnumerable<int> bookIds);
         Task ReturnAsync(int loanItemId);
+        Task<Loan?> GetLoanAsync(int loanId, int userId);
+        Task ExtendLoanAsync(int loanId, int userId, DateTime? newDueDate, int? daysToExtend);
         Task<IEnumerable<Loan>> GetLoanHistoryAsync(int userId);
         Task<IEnumerable<Loan>> GetActiveLoansAsync(int userId);
     }

--- a/BookLibwithSub.Service/Service/LoanService.cs
+++ b/BookLibwithSub.Service/Service/LoanService.cs
@@ -136,6 +136,26 @@ namespace BookLibwithSub.Service.Service
             }
         }
 
+        public async Task<Loan?> GetLoanAsync(int loanId, int userId)
+        {
+            var loan = await _loanRepo.GetByIdAsync(loanId);
+            if (loan == null || loan.Subscription?.UserID != userId)
+                return null;
+            return loan;
+        }
+
+        public async Task ExtendLoanAsync(int loanId, int userId, DateTime? newDueDate, int? daysToExtend)
+        {
+            if (!newDueDate.HasValue && !daysToExtend.HasValue)
+                throw new ArgumentException("Either new due date or days to extend must be provided");
+
+            var loan = await _loanRepo.GetByIdAsync(loanId);
+            if (loan == null || loan.Subscription?.UserID != userId)
+                throw new InvalidOperationException("Loan not found");
+
+            await _loanRepo.ExtendLoanAsync(loan, newDueDate, daysToExtend);
+        }
+
         public async Task<IEnumerable<Loan>> GetLoanHistoryAsync(int userId)
         {
             return await _loanRepo.GetLoansByUserAsync(userId);


### PR DESCRIPTION
## Summary
- add GET /api/loans/{loanId} returning a user's loan with its items
- add PUT /api/loans/{loanId}/extend to update due dates through ILoanService
- enforce ownership checks when fetching or extending loans

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c77c3a948324af046a2b85aa4d6f