### PR TITLE
Add admin transaction retrieval endpoints

### DIFF
--- a/BookLibwithSub.API/Controllers/TransactionsController.cs
+++ b/BookLibwithSub.API/Controllers/TransactionsController.cs
@@ -27,6 +27,26 @@ namespace BookLibwithSub.API.Controllers
             var transactions = await _transactionService.GetUserTransactionsAsync(userId);
             return Ok(transactions);
         }
+
+        [HttpGet("all")]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> GetAll()
+        {
+            var transactions = await _transactionService.GetAllTransactionsAsync();
+            return Ok(transactions);
+        }
+
+        [HttpGet("{id:int}")]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> GetById(int id)
+        {
+            var transaction = await _transactionService.GetTransactionByIdAsync(id);
+            if (transaction == null)
+            {
+                return NotFound();
+            }
+            return Ok(transaction);
+        }
     }
 }
 

--- a/BookLibwithSub.Repo/Interfaces/ITransactionRepository.cs
+++ b/BookLibwithSub.Repo/Interfaces/ITransactionRepository.cs
@@ -10,5 +10,6 @@ namespace BookLibwithSub.Repo.Interfaces
         Task<Transaction?> GetByIdAsync(int id);
         Task UpdateAsync(Transaction transaction);
         Task<List<Transaction>> GetByUserAsync(int userId);
+        Task<List<Transaction>> GetAllAsync();
     }
 }

--- a/BookLibwithSub.Repo/repository/TransactionRepository.cs
+++ b/BookLibwithSub.Repo/repository/TransactionRepository.cs
@@ -39,5 +39,12 @@ namespace BookLibwithSub.Repo.repository
                 .OrderByDescending(t => t.TransactionDate)
                 .ToListAsync();
         }
+
+        public async Task<List<Transaction>> GetAllAsync()
+        {
+            return await _context.Transactions
+                .OrderByDescending(t => t.TransactionDate)
+                .ToListAsync();
+        }
     }
 }

--- a/BookLibwithSub.Service/Interfaces/ITransactionService.cs
+++ b/BookLibwithSub.Service/Interfaces/ITransactionService.cs
@@ -7,6 +7,8 @@ namespace BookLibwithSub.Service.Interfaces
     public interface ITransactionService
     {
         Task<IEnumerable<Transaction>> GetUserTransactionsAsync(int userId);
+        Task<IEnumerable<Transaction>> GetAllTransactionsAsync();
+        Task<Transaction?> GetTransactionByIdAsync(int id);
     }
 }
 

--- a/BookLibwithSub.Service/Service/TransactionService.cs
+++ b/BookLibwithSub.Service/Service/TransactionService.cs
@@ -19,6 +19,16 @@ namespace BookLibwithSub.Service.Service
         {
             return await _transactionRepo.GetByUserAsync(userId);
         }
+
+        public async Task<IEnumerable<Transaction>> GetAllTransactionsAsync()
+        {
+            return await _transactionRepo.GetAllAsync();
+        }
+
+        public async Task<Transaction?> GetTransactionByIdAsync(int id)
+        {
+            return await _transactionRepo.GetByIdAsync(id);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add admin-only `/api/transactions/all` and `/api/transactions/{id}` endpoints
- expose transaction retrieval methods via `ITransactionService`
- implement repository support for fetching transactions

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ca501a60832488d955af6afffab0