### PR TITLE
Fix loan limit counting and subscription activation

### DIFF
--- a/BookLibwithSub.API/Controllers/SubscriptionsController.cs
+++ b/BookLibwithSub.API/Controllers/SubscriptionsController.cs
@@ -52,12 +52,10 @@ namespace BookLibwithSub.API.Controllers
                 // 2) create ZaloPay order (your current behavior)
                 var order = await _zaloPayService.CreateOrderAsync(transaction.TransactionID, userIdOpt.Value);
 
-                // 3) IMMEDIATELY ACTIVATE the most recent subscription for this user
-                //    (we fetch it with plan to compute the end date correctly)
-                var latest = await _subscriptionRepo.GetLatestByUserAsync(userIdOpt.Value);
-                if (latest != null)
+                // 3) IMMEDIATELY ACTIVATE the subscription tied to this transaction
+                if (transaction.SubscriptionID.HasValue)
                 {
-                    var subWithPlan = await _subscriptionRepo.GetByIdWithPlanAsync(latest.SubscriptionID);
+                    var subWithPlan = await _subscriptionRepo.GetByIdWithPlanAsync(transaction.SubscriptionID.Value);
                     if (subWithPlan?.SubscriptionPlan != null)
                     {
                         var nowUtc = DateTime.UtcNow;
@@ -106,11 +104,10 @@ namespace BookLibwithSub.API.Controllers
                 // 2) create ZaloPay order (your current behavior)
                 var order = await _zaloPayService.CreateOrderAsync(transaction.TransactionID, userIdOpt.Value);
 
-                // 3) IMMEDIATELY ACTIVATE (or re-activate) with plan duration
-                var latest = await _subscriptionRepo.GetLatestByUserAsync(userIdOpt.Value);
-                if (latest != null)
+                // 3) IMMEDIATELY ACTIVATE (or re-activate) the renewed subscription
+                if (transaction.SubscriptionID.HasValue)
                 {
-                    var subWithPlan = await _subscriptionRepo.GetByIdWithPlanAsync(latest.SubscriptionID);
+                    var subWithPlan = await _subscriptionRepo.GetByIdWithPlanAsync(transaction.SubscriptionID.Value);
                     if (subWithPlan?.SubscriptionPlan != null)
                     {
                         var nowUtc = DateTime.UtcNow;

--- a/BookLibwithSub.Repo/repository/LoanRepository.cs
+++ b/BookLibwithSub.Repo/repository/LoanRepository.cs
@@ -22,9 +22,14 @@ namespace BookLibwithSub.Repo.repository
             if (start.Kind != DateTimeKind.Utc) start = DateTime.SpecifyKind(start, DateTimeKind.Utc);
             if (end.Kind != DateTimeKind.Utc) end = DateTime.SpecifyKind(end, DateTimeKind.Utc);
 
+            // Only count items that are currently borrowed. Items that have been
+            // returned shouldn't contribute to the daily/monthly borrowing limits.
+            // Checking ReturnedDate instead of Status is more resilient in case the
+            // status field isn't updated for some reason.
             return await _context.LoanItems
                 .Where(li => li.Loan.SubscriptionID == subscriptionId &&
-                             li.Loan.LoanDate >= start && li.Loan.LoanDate < end)
+                             li.Loan.LoanDate >= start && li.Loan.LoanDate < end &&
+                             li.ReturnedDate == null)
                 .CountAsync();
         }
 


### PR DESCRIPTION
## Summary
- do not include returned loan items when counting daily and monthly borrow limits
- activate the subscription associated with a purchase instead of the latest subscription

## Testing
- `dotnet test SWD392.BookLibwithSub.API.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ac198cf09483248fbc52faa68aff43